### PR TITLE
only one level in subrelation-tree

### DIFF
--- a/api/details.py
+++ b/api/details.py
@@ -190,9 +190,9 @@ class RelationInfo(GenericDetails):
         h = mapdb.tables.hierarchy.data
 
         if subs:
-            w = sa.select([h.c.child], distinct=True).where(h.c.parent == rid)
+            w = sa.select([h.c.child], distinct=True).where(h.c.parent == rid).where(h.c.depth == 2)
         else:
-            w = sa.select([h.c.parent], distinct=True).where(h.c.child == rid)
+            w = sa.select([h.c.parent], distinct=True).where(h.c.child == rid).where(h.c.depth == 2)
 
         sections = sa.select([r.c.id, r.c.name, r.c.intnames,
                               r.c[self.level_column].label('level')])\


### PR DESCRIPTION
Currently a super-relation shows all children, from all subrelations as sections (see e.g. [E1 hiking superroute](hiking.waymarkedtrails.org/#route?id=371743)

This patch restores similar behaviour as before the sqlalchemy port. See also a [pull request from 2012](https://github.com/lonvia/waymarked-trails-site/pull/86/files); ordering of the section list is lost now as well, but that's an additional issue.