### PR TITLE
fixup subroutes hovering

### DIFF
--- a/frontend/static/js/app.js
+++ b/frontend/static/js/app.js
@@ -274,7 +274,7 @@ Osgende.RouteDetails = function(map, container) {
     })
     .on("panelbeforeclose", function() {
         map.vector_layer.setStyle(null);
-        map.vector_layer_detailedroute.setStyle(null);
+        map.vector_layer_detailedroute.setSource(null);
     });
 
   $(".zoom-button").on("click", function(event) {


### PR DESCRIPTION
In #239 I missed to clear the new vector_layer_detailedroute, when the panel is closing.
Please see a fixup patch attached.

If we only set the details-layer to invisible on closing the details box,
it is shown again, when hover leaves any other route from vector_layer.
So it is better to clear the details layer, when the details panel is closed.