### PR TITLE
footer: search icon instead of text

### DIFF
--- a/config/i18n.cfg
+++ b/config/i18n.cfg
@@ -2,3 +2,5 @@
 
 [jinja2: frontend/templates/**.html]
 encoding = utf-8
+silent=False
+extensions=webassets.ext.jinja2.AssetsExtension

--- a/django/locale/qot/LC_MESSAGES/django.po
+++ b/django/locale/qot/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Waymarked Trails Map VERSION\n"
 "Report-Msgid-Bugs-To: lonvia@denofr.de\n"
-"POT-Creation-Date: 2016-03-21 21:07+0100\n"
+"POT-Creation-Date: 2016-08-09 23:28+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,15 +17,19 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.2.0\n"
 
-#: frontend/templates/pages/routes.html:52
+#: frontend/templates/index.html:38
+msgid "About the map"
+msgstr ""
+
+#: frontend/templates/pages/routes.html:54
 msgid "Accumulated ascent"
 msgstr ""
 
-#: frontend/templates/pages/routes.html:56
+#: frontend/templates/pages/routes.html:58
 msgid "Accumulated descent"
 msgstr ""
 
-#: frontend/templates/pages/routes.html:47
+#: frontend/templates/pages/routes.html:49
 msgid "Altitude (m)"
 msgstr ""
 
@@ -34,7 +38,7 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
-#: frontend/templates/error.html:8 frontend/templates/help-base.html:8
+#: frontend/templates/error.html:8 frontend/templates/help-base.html:10
 msgid "Back to map"
 msgstr ""
 
@@ -54,15 +58,15 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: config/sites/cycling.py:30 frontend/templates/base.html:27
+#: config/sites/cycling.py:30 frontend/templates/base.html:28
 msgid "Cycling"
 msgstr ""
 
-#: frontend/templates/pages/routes.html:49
+#: frontend/templates/pages/routes.html:51
 msgid "Distance (km)"
 msgstr ""
 
-#: frontend/templates/pages/routes.html:45
+#: frontend/templates/pages/routes.html:47
 msgid "Elevation profile"
 msgstr ""
 
@@ -87,7 +91,7 @@ msgstr ""
 msgid "GPX"
 msgstr ""
 
-#: config/sites/hiking.py:30 frontend/templates/base.html:27
+#: config/sites/hiking.py:30 frontend/templates/base.html:28
 msgid "Hiking"
 msgstr ""
 
@@ -95,11 +99,11 @@ msgstr ""
 msgid "Hill shading"
 msgstr ""
 
-#: frontend/templates/base.html:29
+#: frontend/templates/base.html:30
 msgid "Horse Riding"
 msgstr ""
 
-#: config/sites/skating.py:29 frontend/templates/base.html:28
+#: config/sites/skating.py:29 frontend/templates/base.html:29
 msgid "Inline Skating"
 msgstr ""
 
@@ -107,7 +111,7 @@ msgstr ""
 msgid "It looks like the page you are looking for doesn't exist. If you think that you have found a broken link, don't hesitate to contact us."
 msgstr ""
 
-#: frontend/templates/index.html:50
+#: frontend/templates/index.html:52
 msgid "JavaScript needs to be activated to use this service."
 msgstr ""
 
@@ -120,11 +124,11 @@ msgstr ""
 msgid "Last update"
 msgstr ""
 
-#: frontend/templates/index.html:35
+#: frontend/templates/index.html:37
 msgid "Locate me"
 msgstr ""
 
-#: config/sites/mtb.py:29 frontend/templates/base.html:28
+#: config/sites/mtb.py:29 frontend/templates/base.html:29
 msgid "MTB"
 msgstr ""
 
@@ -132,7 +136,7 @@ msgstr ""
 msgid "Map data © [OpenStreetMap](http://www.openstreetmap.org) under [ODbL](http://www.openstreetmap.org/copyright)"
 msgstr ""
 
-#: frontend/templates/index.html:34 frontend/templates/pages/settings.html:12
+#: frontend/templates/index.html:36 frontend/templates/pages/settings.html:12
 msgid "Map settings"
 msgstr ""
 
@@ -156,7 +160,7 @@ msgstr ""
 msgid "Official length"
 msgstr ""
 
-#: frontend/templates/pages/routes.html:72
+#: frontend/templates/pages/routes.html:74
 msgid "OpenStreetMap tags"
 msgstr ""
 
@@ -168,7 +172,7 @@ msgstr ""
 msgid "Original message"
 msgstr ""
 
-#: frontend/templates/pages/routes.html:64
+#: frontend/templates/pages/routes.html:66
 msgid "Part of"
 msgstr ""
 
@@ -184,15 +188,15 @@ msgstr ""
 msgid "Route layer"
 msgstr ""
 
-#: frontend/templates/index.html:38 frontend/templates/pages/routelist.html:5
+#: frontend/templates/index.html:40 frontend/templates/pages/routelist.html:5
 msgid "Routes"
 msgstr ""
 
-#: frontend/templates/index.html:32 frontend/templates/pages/search.html:5
+#: frontend/templates/index.html:33 frontend/templates/pages/search.html:5
 msgid "Search"
 msgstr ""
 
-#: frontend/templates/pages/routes.html:64
+#: frontend/templates/pages/routes.html:66
 msgid "Sections"
 msgstr ""
 
@@ -228,15 +232,15 @@ msgstr ""
 msgid "Waymarked Trails shows winter sport slopes, with maps and information from OpenStreetMap."
 msgstr ""
 
-#: frontend/templates/pages/routes.html:40
+#: frontend/templates/pages/routes.html:41
 msgid "Website"
 msgstr ""
 
-#: frontend/templates/pages/routes.html:41
+#: frontend/templates/pages/routes.html:42
 msgid "Wikipedia"
 msgstr ""
 
-#: config/sites/slopes.py:29 frontend/templates/base.html:29
+#: config/sites/slopes.py:29 frontend/templates/base.html:30
 msgid "Winter Sport Slopes"
 msgstr ""
 
@@ -248,11 +252,11 @@ msgstr ""
 msgid "Zoom in to see more routes"
 msgstr ""
 
-#: config/sites/_common.py:41
+#: config/sites/_common.py:43
 msgid "continental"
 msgstr ""
 
-#: config/sites/_common.py:47
+#: config/sites/_common.py:49
 msgid "downhill"
 msgstr ""
 
@@ -260,15 +264,15 @@ msgstr ""
 msgid "elevation data by [SRTM/ASTER](help/acknowledgements)"
 msgstr ""
 
-#: config/sites/_common.py:51
+#: config/sites/_common.py:53
 msgid "hike"
 msgstr ""
 
-#: config/sites/_common.py:42
+#: config/sites/_common.py:44
 msgid "national"
 msgstr ""
 
-#: config/sites/_common.py:48
+#: config/sites/_common.py:50
 msgid "nordic"
 msgstr ""
 
@@ -276,23 +280,23 @@ msgstr ""
 msgid "osmc:symbol tag values displayed on the map"
 msgstr ""
 
-#: config/sites/_common.py:40 config/sites/_common.py:53
+#: config/sites/_common.py:42 config/sites/_common.py:55
 msgid "other"
 msgstr ""
 
-#: config/sites/_common.py:43
+#: config/sites/_common.py:45
 msgid "regional"
 msgstr ""
 
-#: config/sites/_common.py:49
+#: config/sites/_common.py:51
 msgid "skitour"
 msgstr ""
 
-#: config/sites/_common.py:50
+#: config/sites/_common.py:52
 msgid "sled"
 msgstr ""
 
-#: config/sites/_common.py:52
+#: config/sites/_common.py:54
 msgid "sleigh"
 msgstr ""
 

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -29,11 +29,13 @@
   <form id="searchform" accept-charset="UTF-8" action="#" class ="footer-form-left search-form">
     <input type="search" size="30" name="query" tabindex="1" class="ui-mini" data-theme="a" />
   </form>
-  <a href="#search" id="searchbutton" class="ui-btn ui-mini ui-corner-all ui-button-inline footer-button-left">{% trans %}Search{% endtrans %}</a>
+  <div id="searchbutton" data-role="footer-controlgroup" data-type="horizontal" class="ui-mini footer-button-left">
+	<a href="#search" class="ui-btn ui-icon-search ui-btn-icon-notext" title="{% trans %}Search{% endtrans %}">{% trans %}Search{% endtrans %}</a>
+  </div>
   <div data-role="footer-controlgroup" data-type="horizontal" class="ui-mini footer-center">
-    <a href="#settings" class="ui-btn ui-icon-gear ui-btn-icon-notext">{% trans %}Map settings{% endtrans %}</a>
-    <a href="#" class="ui-btn ui-icon-location ui-btn-icon-notext btn-func-location">{% trans %}Locate me{% endtrans %}</a>
-    <a href="help" data-ajax="false" class="ui-btn ui-icon-info ui-btn-icon-notext lang-link">Info</a>
+    <a href="#settings" class="ui-btn ui-icon-gear ui-btn-icon-notext" title="{% trans %}Map settings{% endtrans %}">{% trans %}Map settings{% endtrans %}</a>
+    <a href="#" class="ui-btn ui-icon-location ui-btn-icon-notext btn-func-location" title="{% trans %}Locate me{% endtrans %}">{% trans %}Locate me{% endtrans %}</a>
+    <a href="help" data-ajax="false" class="ui-btn ui-icon-info ui-btn-icon-notext lang-link" title="{% trans %}About the map{% endtrans %}">{% trans %}About the map{% endtrans %}</a>
   </div>
   <a href="#routelist" class="ui-btn ui-mini ui-corner-all ui-button-inline footer-button-right maplink">{% trans %}Routes{% endtrans %}</a>
 {% endblock %}


### PR DESCRIPTION
* replace string "search" by corresponding icon
* add icon strings as title attribute to allow hovering (on desktop version)
* add translatable string to the info-button
* re-generate translations, needs AssetsExtension

Fixes #162