### PR TITLE
fix maplinks exceeding titlebar at low screen height

### DIFF
--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -29,7 +29,7 @@ a:hover {
     top: 75px
 }
 
-@media screen and (max-width:720px) {
+@media screen and (max-height: 500px), screen and (max-width:720px) {
     #map_maplinks {
         display: none
     }


### PR DESCRIPTION
don't display maplinks at reduced header height

Fixes #226