### PR TITLE
Please enable gzip compression for json

### DIFF
--- a/api/details.py
+++ b/api/details.py
@@ -229,6 +229,7 @@ class RelationInfo(GenericDetails):
 
 
     @cherrypy.expose
+    @cherrypy.tools.gzip(mime_types=['application/gpx+xml'])
     def gpx(self, oid, **params):
         r = cherrypy.request.app.config['DB']['map'].tables.routes.data
         sel = sa.select([r.c.name, r.c.intnames,
@@ -239,6 +240,7 @@ class RelationInfo(GenericDetails):
 
 
     @cherrypy.expose
+    @cherrypy.tools.gzip(mime_types=['text/json'])
     def geometry(self, oid, factor=None, **params):
         r = cherrypy.request.app.config['DB']['map'].tables.routes.data
         if factor is None:
@@ -253,6 +255,7 @@ class RelationInfo(GenericDetails):
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
+    @cherrypy.tools.gzip(mime_types=['application/json'])
     def elevation(self, oid, segments=None, **params):
         if segments is not None and segments.isdigit():
             segments = int(segments)

--- a/api/listings.py
+++ b/api/listings.py
@@ -68,6 +68,7 @@ class RouteLists(GenericList):
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
+    @cherrypy.tools.gzip(mime_types=['application/json'])
     def by_area(self, bbox, limit=None, **params):
         b = api.common.Bbox(bbox)
         limit = self.num_param(limit, 20, 100)
@@ -91,6 +92,7 @@ class RouteLists(GenericList):
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
+    @cherrypy.tools.gzip(mime_types=['application/json'])
     def by_ids(self, ids, limit=None, **params):
         i = [int(n) for n in ids.split(',') if n.isdigit()][:100] # allow max 100 integer ids
 
@@ -106,6 +108,7 @@ class RouteLists(GenericList):
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
+    @cherrypy.tools.gzip(mime_types=['application/json'])
     def search(self, query=None, limit=None, page=None):
         cfg = cherrypy.request.app.config
         limit = self.num_param(limit, 10, 100)
@@ -157,6 +160,7 @@ class RouteLists(GenericList):
 
 
     @cherrypy.expose
+    @cherrypy.tools.gzip(mime_types=['text/json'])
     def segments(self, relations=None, bbox=None, **params):
         b = api.common.Bbox(bbox)
 
@@ -179,6 +183,7 @@ class SlopeLists(GenericList):
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
+    @cherrypy.tools.gzip(mime_types=['application/json'])
     def by_area(self, bbox, limit=None, **params):
         b = api.common.Bbox(bbox)
         limit = self.num_param(limit, 20, 100)
@@ -223,6 +228,7 @@ class SlopeLists(GenericList):
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
+    @cherrypy.tools.gzip(mime_types=['application/json'])
     def search(self, query=None, limit=None, page=None):
         cfg = cherrypy.request.app.config
         limit = self.num_param(limit, 10, 100)
@@ -288,6 +294,7 @@ class SlopeLists(GenericList):
 
 
     @cherrypy.expose
+    @cherrypy.tools.gzip(mime_types=['text/json'])
     def segments(self, relations=None, ways=None, waysets=None, bbox=None, **params):
         b = api.common.Bbox(bbox)
         tables = cherrypy.request.app.config['DB']['map'].tables

--- a/api/vector_tiles.py
+++ b/api/vector_tiles.py
@@ -33,6 +33,7 @@ class TilesApi(object):
     @cherrypy.expose
     @cherrypy.tools.response_headers(headers=[('Content-Type', 'text/json')])
     @cherrypy.tools.expires(secs=21600, force=True)
+    @cherrypy.tools.gzip(mime_types=['text/json'])
     def index(self, zoom, x, y):
         if zoom != '12':
             raise cherrypy.HTTPError(400, 'Only zoom level 12 available')


### PR DESCRIPTION
I'd suggest to enable gzip compression for the new vector tiles json data and for 'old' json APIs. This could be done as shown here using cherrypy.tools.gzip().
Or do you prefer apache to do the compression?

A list of currently uncompressed files can be retrieved using Google [pagespeed](https://developers.google.com/speed/pagespeed/insights/?url=http://hiking.waymarkedtrails.org/#routelist?map=13!46.7396!7.7866&tab=desktop).