### PR TITLE
Vector tiles 2

### DIFF
--- a/api/vector_tiles.py
+++ b/api/vector_tiles.py
@@ -58,7 +58,7 @@ class TilesApi(object):
         mapdb = cherrypy.request.app.config['DB']['map']
         d = mapdb.tables.style.data
 
-        q = sa.select([d.c.rels, d.c.allshields.label('shields'),
+        q = sa.select([d.c.rels, d.c.allrels, d.c.allshields.label('shields'),
                     d.c.network, d.c.style, d.c['class'],
                     d.c.geom.ST_Intersection(b.as_sql()).ST_AsGeoJSON().label('geom')])\
               .where(d.c.geom.intersects(b.as_sql()))\
@@ -76,7 +76,8 @@ class TilesApi(object):
             out.write('{ "type": "Feature", "geometry":')
             out.write(r['geom'])
             out.write(', "properties" : ')
-            json.dump({ 'relations' : r['rels'],
+            json.dump({ 'toprelations' : r['rels'],
+                        'allrelations' : r['allrels'],
                         'shields' : r['shields'],
                         'network' : r['network'],
                         'style' : r['style'],

--- a/db/tables/routes.py
+++ b/db/tables/routes.py
@@ -146,7 +146,8 @@ class RouteSegmentStyle(SegmentStyle):
                 Column('style', Integer),
                 Column('inrshields', ARRAY(String)),
                 Column('allshields', ARRAY(String)),
-                Column('rels', ARRAY(BigInteger))
+                Column('rels', ARRAY(BigInteger)),
+                Column('allrels', ARRAY(BigInteger))
                )
 
     def segment_info(self):
@@ -163,11 +164,13 @@ class RouteSegmentInfo:
         self.inrshields = set()
         self.allshields = set()
         self.rels = []
+        self.allrels = []
 
     def append(self, relinfo):
         if relinfo['top']:
             self.compute_info(self, relinfo)
             self.rels.append(relinfo['id'])
+        self.allrels.append(relinfo['id'])
 
     def add_shield(self, shield, isinr):
         if isinr and len(self.inrshields) < 5:
@@ -182,5 +185,6 @@ class RouteSegmentInfo:
                  'class' : self.classification,
                  'inrshields' : list(self.inrshields),
                  'allshields' : list(self.allshields),
+                 'allrels' : self.allrels,
                  'rels' : self.rels
                }

--- a/frontend/static/js/app.js
+++ b/frontend/static/js/app.js
@@ -8,7 +8,7 @@ Osgende.highlight_stroke = new ol.style.Stroke({
 // return a function to style relation rid with highlight_stroke
 Osgende.highlight_style = function (rid) {
   return function (feature, resolution) {
-    if ($.inArray(rid, Osgende.get_relation_ids(feature)) !== -1) {
+    if ($.inArray(rid, Osgende.get_allrelation_ids(feature)) !== -1) {
       return new ol.style.Style({
                       stroke: Osgende.highlight_stroke,
                       zindex: 1

--- a/frontend/static/js/map.js
+++ b/frontend/static/js/map.js
@@ -58,8 +58,11 @@ Osgende.Geolocator = function(map) {
 }
 
 // extract relation IDs from feature
-Osgende.get_relation_ids = function (feature) {
-  return feature.getProperties()['relations'];
+Osgende.get_toprelation_ids = function (feature) {
+  return feature.getProperties()['toprelations'];
+}
+Osgende.get_allrelation_ids = function (feature) {
+  return feature.getProperties()['allrelations'];
 }
 
 // Vector layer available for BaseMap object?
@@ -135,7 +138,7 @@ Osgende.BaseMapControl = function(settings) {
     var p2 = obj.map.getCoordinateFromPixel([evt.pixel[0] + 3, evt.pixel[1] + 3]);
     var ext = ol.extent.boundingExtent([p1, p2]);
     obj.vroute_layer.getSource().forEachFeatureIntersectingExtent(ext, function onOpenDetails(feature, layer) {
-      var rels = Osgende.get_relation_ids(feature);
+      var rels = Osgende.get_toprelation_ids(feature);
       if (rels)
         relations = relations.concat(rels);
     });

--- a/frontend/static/js/map.js
+++ b/frontend/static/js/map.js
@@ -57,6 +57,18 @@ Osgende.Geolocator = function(map) {
   return obj;
 }
 
+// extract relation IDs from feature
+Osgende.get_relation_ids = function (feature) {
+  return feature.getProperties()['relations'];
+}
+
+// Vector layer available for BaseMap object?
+Osgende.has_vector_tiles = function (obj) {
+  return obj.vroute_layer
+      && obj.map.getView().get('resolution') <= obj.vroute_layer.get('maxResolution')
+      && obj.map.getView().get('resolution') >= obj.vroute_layer.get('minResolution');
+}
+
 Osgende.BaseMapControl = function(settings) {
   var obj = {};
   $("#javascript-warning").remove();
@@ -110,11 +122,6 @@ Osgende.BaseMapControl = function(settings) {
     });
   }
 
-  // extract relation IDs from feature
-  function get_relation_ids(feature) {
-    return feature.getProperties()['relations'];
-  }
-
   // helper function: remove duplicates from an array
   function unique(array) {
     return $.grep(array, function(el, index) {
@@ -128,7 +135,7 @@ Osgende.BaseMapControl = function(settings) {
     var p2 = obj.map.getCoordinateFromPixel([evt.pixel[0] + 3, evt.pixel[1] + 3]);
     var ext = ol.extent.boundingExtent([p1, p2]);
     obj.vroute_layer.getSource().forEachFeatureIntersectingExtent(ext, function onOpenDetails(feature, layer) {
-      var rels = get_relation_ids(feature);
+      var rels = Osgende.get_relation_ids(feature);
       if (rels)
         relations = relations.concat(rels);
     });


### PR DESCRIPTION
As a follow-up to the vector-tiles change last year, this PR removes calls to the sements-API and uses the vector-tiles information instead.
For zoom-levels below 12 the current behaviour is preserved.

For sub-/superroutes hovering, I'd like to add another column to the defstyle table. But I need your help to implement the database creation step. I've tested the code altering my existing database. Where is the defstyle table filled, so that I can add the data on `makedb.py <schema> import`?

